### PR TITLE
Fix filename in setup.py

### DIFF
--- a/{{cookiecutter.project_shortname}}/setup.py
+++ b/{{cookiecutter.project_shortname}}/setup.py
@@ -3,7 +3,7 @@ import os
 from setuptools import setup
 
 
-with open(os.path.join('{{cookiecutter.project_shortname}}', 'package.json')) as f:
+with open(os.path.join('{{cookiecutter.project_shortname}}', 'package-info.json')) as f:
     package = json.load(f)
 
 package_name = package["name"].replace(" ", "_").replace("-", "_")


### PR DESCRIPTION
Running `python setup.py sdist` on a project that's been copied with cookiecutter doesn't work because it can't find package.json in the subdirectory named after the project.

I'm not actually sure if this is the correct fix because there are two identical files in a repo setup by cookiecutter:
```
./package.json
./{{cookiecutter.project_shortname}}/package-info.json
```

I wasn't totally sure whether to use this fix:
```
with open(os.path.join('{{cookiecutter.project_shortname}}', 'package-info.json')) as f:
```
or this one:
```
with open('package.json') as f:
```
Both seem to work.